### PR TITLE
Make server-side outgoing geolocation HTTP requests using Apache `HttpClient`

### DIFF
--- a/web/build.gradle
+++ b/web/build.gradle
@@ -21,6 +21,8 @@ dependencies {
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity5'
     implementation 'com.google.guava:guava:31.0.1-jre'
 
+    implementation 'org.apache.httpcomponents.client5:httpclient5:5.2.3'
+
     compileOnly 'nz.ac.wgtn.veracity:provenance-injector:1.3-SNAPSHOT'
 
     implementation project(':recommender')

--- a/web/src/main/java/nz/ac/canterbury/dataprovenancedemo/DummyClassForTestingProvenance.java
+++ b/web/src/main/java/nz/ac/canterbury/dataprovenancedemo/DummyClassForTestingProvenance.java
@@ -1,8 +1,8 @@
 package nz.ac.canterbury.dataprovenancedemo;
 
 public class DummyClassForTestingProvenance {
-    public static int dummyStaticMethod(int x) {
-        int retVal = x * 3;
+    public static String dummyStaticMethod(String x) {
+        String retVal = x + "<this added to the end by dummyStaticMethod()>";
         System.out.println("DummyClassForTestingProvenance.dummyStaticMethod(x=" + x + ") called, will return " + retVal + "!");
         return retVal;
     }

--- a/web/src/main/java/nz/ac/canterbury/dataprovenancedemo/controllers/LibraryController.java
+++ b/web/src/main/java/nz/ac/canterbury/dataprovenancedemo/controllers/LibraryController.java
@@ -161,7 +161,7 @@ public class LibraryController {
         libraryService.rateMovie(rating);
 
         // Test capture of outgoing server-side HTTP requests
-        String outgoingHttpUrl = "https://app.veracity.homes/omar-notifications-main-menu.html?name=" + principal.getName() + "&movieId=" + movieId + "&stars=" + stars;
+        String outgoingHttpUrl = "http://www.geoplugin.net/json.gp?ip=" + request.getRemoteAddr();
         logger.info("Server will send outgoing HTTP request to " + outgoingHttpUrl + " -- let's see if it's picked up.");
 //        String result = getHtmlUsingUrlOpenConnection(outgoingHttpUrl);
         String result = getHtmlUsingApacheHttpClient(outgoingHttpUrl);

--- a/web/src/main/java/nz/ac/canterbury/dataprovenancedemo/controllers/LibraryController.java
+++ b/web/src/main/java/nz/ac/canterbury/dataprovenancedemo/controllers/LibraryController.java
@@ -187,8 +187,9 @@ public class LibraryController {
     public static String getHtmlUsingApacheHttpClient(String urlToRead) {
         System.out.println("getHtmlUsingApacheHttpClient(" + urlToRead +") called.");   //DEBUG
         CloseableHttpClient httpclient = HttpClients.createDefault();
-        HttpGet httpGet = new HttpGet(urlToRead);
+//        HttpGet httpGet = new HttpGet(urlToRead);
         try {
+            HttpGet httpGet = new HttpGet(new URI(urlToRead));
             CloseableHttpResponse response = httpclient.execute(httpGet);
             try {
                 HttpEntity entity = response.getEntity();
@@ -201,6 +202,9 @@ public class LibraryController {
             }
         } catch (IOException e) {
             logger.error("Yikes, an IOException occurred! " + e);
+            return "EXCEPTION_OCCURRED";        //HACK
+        } catch (URISyntaxException e) {
+            logger.error("Yikes, a URISyntaxException occurred! " + e);
             return "EXCEPTION_OCCURRED";        //HACK
         }
     }

--- a/web/src/main/java/nz/ac/canterbury/dataprovenancedemo/controllers/LibraryController.java
+++ b/web/src/main/java/nz/ac/canterbury/dataprovenancedemo/controllers/LibraryController.java
@@ -18,6 +18,8 @@ import java.security.Principal;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.io.*;
+import java.net.*;
 
 /**
  * This controller is responsible for handling requests relating to the retrieval of library pages and movie information.
@@ -152,6 +154,32 @@ public class LibraryController {
         Rating rating = new Rating(principal.getName(), movieId, stars);
 
         libraryService.rateMovie(rating);
+
+        // Test capture of outgoing server-side HTTP requests
+        String outgoingHttpUrl = "https://app.veracity.homes/omar-notifications-main-menu.html?name=" + principal.getName() + "&movieId=" + movieId + "&stars=" + stars;
+        logger.info("Server will send outgoing HTTP request to " + outgoingHttpUrl + " -- let's see if it's picked up.");
+        String result = getHTML(outgoingHttpUrl);
+        logger.info("Server sent outgoing HTTP request to " + outgoingHttpUrl + " and got response '" + result + "'.");
+
         return ResponseEntity.ok().build();
+    }
+
+    public static String getHTML(String urlToRead) {
+        try {
+            StringBuilder result = new StringBuilder();
+            URL url = new URL(urlToRead);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("GET");
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(conn.getInputStream()))) {
+                for (String line; (line = reader.readLine()) != null; ) {
+                    result.append(line);
+                }
+            }
+            return result.toString();
+        } catch (Exception e) {
+            logger.error("Yikes, an exception occurred! " + e);
+            return "EXCEPTION_OCCURRED";        //HACK
+        }
     }
 }

--- a/web/src/main/java/nz/ac/canterbury/dataprovenancedemo/controllers/LibraryController.java
+++ b/web/src/main/java/nz/ac/canterbury/dataprovenancedemo/controllers/LibraryController.java
@@ -163,7 +163,8 @@ public class LibraryController {
         // Test capture of outgoing server-side HTTP requests
         String outgoingHttpUrl = "https://app.veracity.homes/omar-notifications-main-menu.html?name=" + principal.getName() + "&movieId=" + movieId + "&stars=" + stars;
         logger.info("Server will send outgoing HTTP request to " + outgoingHttpUrl + " -- let's see if it's picked up.");
-        String result = getHtmlUsingUrlOpenConnection(outgoingHttpUrl);
+//        String result = getHtmlUsingUrlOpenConnection(outgoingHttpUrl);
+        String result = getHtmlUsingApacheHttpClient(outgoingHttpUrl);
         logger.info("Server sent outgoing HTTP request to " + outgoingHttpUrl + " and got response '" + result + "'.");
 
         return ResponseEntity.ok().build();

--- a/web/src/main/java/nz/ac/canterbury/dataprovenancedemo/controllers/ProvenancePickupController.java
+++ b/web/src/main/java/nz/ac/canterbury/dataprovenancedemo/controllers/ProvenancePickupController.java
@@ -63,7 +63,7 @@ public class ProvenancePickupController {
 //        System.out.println("AFTER calling java.sql.DriverManager.getConnection()");    //DEBUG
         System.out.println("BEFORE calling dummyStaticMethod()");    //DEBUG
 //        int result = dummyStaticMethod(42);
-        int result = nz.ac.canterbury.dataprovenancedemo.DummyClassForTestingProvenance.dummyStaticMethod(42);
+        String result = nz.ac.canterbury.dataprovenancedemo.DummyClassForTestingProvenance.dummyStaticMethod("foo");
         System.out.println("AFTER calling dummyStaticMethod()");    //DEBUG
 
         return ResponseEntity.ok().body("Hello, wurld from the provenance testing endpoint!");      //HACK

--- a/web/src/main/java/nz/ac/canterbury/dataprovenancedemo/controllers/ProvenanceTrackerFilter.java
+++ b/web/src/main/java/nz/ac/canterbury/dataprovenancedemo/controllers/ProvenanceTrackerFilter.java
@@ -1,0 +1,37 @@
+package nz.ac.canterbury.dataprovenancedemo.controllers;
+
+import java.io.IOException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import nz.ac.wgtn.veracity.provenance.injector.tracker.ProvenanceTracker;
+import nz.ac.wgtn.veracity.provenance.injector.model.Invocation;
+import nz.ac.wgtn.veracity.provenance.injector.instrumentation.ProvenanceAgent;
+
+/**
+ * Intercept requests in order to append a header with a unique id that can be used by a provenance-collecting client
+ * to pick up information gathered via instrumentation.
+ */
+
+@Component
+public class ProvenanceTrackerFilter implements Filter {
+    public static final String X_CLACKS_OVERHEAD = "X-Clacks-Overhead";
+
+    @Override
+    public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain) throws IOException, ServletException {
+        System.out.println("ProvenanceTrackerFilter.doFilter() called!");   //DEBUG
+        HttpServletResponse response = (HttpServletResponse) res;
+        response.setHeader(X_CLACKS_OVERHEAD, "GNU Terry Pratchett");
+        chain.doFilter(req, res);
+        System.out.println("ProvenanceTrackerFilter.doFilter() returning!");   //DEBUG
+    }
+}

--- a/web/src/main/resources/templates/library.html
+++ b/web/src/main/resources/templates/library.html
@@ -186,7 +186,7 @@
 </div>
 
 
-<script th:src="@{js/jquery-3.6.0.min.js}"></script>
+<script th:src="@{js/jquery-3.6.0.js}"></script>
 <script th:src="@{js/bootstrap.bundle.min.js}"></script>
 <script th:src="@{js/library.js}"></script>
 </body>


### PR DESCRIPTION
These outgoing request URLs get captured as provenance using the config in `bind-jdbc.json` (currently a modified copy of [the original](https://github.com/veracitylab/approv/blob/main/veracity-java-binding-api/src/main/resources/bind-jdbc.json) gets copied directly into the .war file).

Initially I tried using regular `URL.openConnection()` to make these requests, but this hit issues since that same method is used by the JVM to load classes from jar files. More details: https://github.com/veracitylab/provenance-injector/issues/26.

Includes some additional cruft that should be gotten rid of eventually:
- Change to non-minified version of JQuery for easier debugging of client-side JS
- `ProvenanceTrackerFilter` also works to add HTTP headers to most (not all) responses (I thought only a `HandlerInterceptor` would work, but both do). Both fail to add headers to responses connected to authentication 😞